### PR TITLE
Use relative paths for backend volumes

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -71,9 +71,9 @@ services:
     ports: ["8000:8000"]
     volumes:
       - ./makerworks-backend:/app
-      - /Users/stephenchartrand/Downloads/makerworks-repo/makerworks/uploads:/app/uploads
-      - /Users/stephenchartrand/Downloads/makerworks-repo/makerworks/thumbnails:/thumbnails
-      - /Users/stephenchartrand/Downloads/makerworks-repo/makerworks/models:/models
+      - ${HOST_UPLOADS_DIR:-./uploads}:/app/uploads
+      - ${HOST_THUMBNAILS_DIR:-./thumbnails}:/thumbnails
+      - ${HOST_MODELS_DIR:-./models}:/models
     env_file:
       - ./makerworks-backend/.env.dev
       - ./makerworks-backend/.env

--- a/models/.gitkeep
+++ b/models/.gitkeep
@@ -1,0 +1,1 @@
+# Placeholder to keep directory tracked by Git


### PR DESCRIPTION
## Summary
- replace absolute backend volume paths with configurable relative paths
- add placeholder models directory for volume mount

## Testing
- `pre-commit run --files docker-compose.yml models/.gitkeep` *(fails: cannot find @eslint/js; ModuleNotFoundError: No module named 'fastapi')*
- `docker compose up` *(fails: command not found: docker)*

------
https://chatgpt.com/codex/tasks/task_e_68a8372efe74832f9fd21c3f3789bd0c

## Summary by Sourcery

Use environment variables for backend volume mounts and add a placeholder models directory

Enhancements:
- Replace hardcoded absolute host paths with configurable environment-variable-based relative paths for backend volume mounts
- Add placeholder models directory with .gitkeep to support model volume mount