### PR TITLE
Require explicit backend config

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@ Dockerized monorepo containing a FastAPI backend and a React/Vite frontend.
 
 1. Copy `makerworks/infra/.env.example` to `makerworks/infra/.env` and adjust values as needed. The sample file includes
    placeholders for Postgres, Redis, OAuth providers, Stripe, storage backends and other integrations. Stub values are
-   provided so the stack can boot without real secrets.
+   provided so the stack can boot without real secrets. At minimum, define
+   `DATABASE_URL`, `REDIS_URL`, and `SECRET_KEY`; the backend requires these
+   environment variables and no built-in defaults are used.
 2. Start the development stack:
    ```bash
    make docker-up

--- a/makerworks/backend/app/config.py
+++ b/makerworks/backend/app/config.py
@@ -4,14 +4,14 @@ from pydantic_settings import BaseSettings
 
 class Settings(BaseSettings):
     database_url: str = Field(
-        default="postgresql+psycopg://makerworks:makerworks@postgres:5432/makerworks",
-        validation_alias=AliasChoices("DATABASE_URL", "POSTGRES_URL"),
+        ..., validation_alias=AliasChoices("DATABASE_URL", "POSTGRES_URL")
     )
     redis_url: str = Field(
-        default="redis://redis:6379/0",
-        validation_alias=AliasChoices("REDIS_URL",),
+        ..., validation_alias=AliasChoices("REDIS_URL",)
     )
-    secret_key: str = Field(default="change-me", validation_alias=AliasChoices("SECRET_KEY",))
+    secret_key: str = Field(
+        ..., validation_alias=AliasChoices("SECRET_KEY",)
+    )
 
 
 settings = Settings()


### PR DESCRIPTION
## Summary
- remove default database, redis, and secret key values so backend uses only environment-provided configuration
- document required environment variables

## Testing
- `SKIP=pytest,bump-version,frontend-lint python -m pre_commit run --files makerworks/backend/app/config.py README.md`
- `make backend-test` *(fails: no such table: api_keys)*

------
https://chatgpt.com/codex/tasks/task_e_68a8a5ed1fe8832fba35b5ecce489f38

## Summary by Sourcery

Require explicit environment configuration for the backend by dropping built-in defaults and updating documentation

Enhancements:
- Enforce explicit backend configuration by removing default values for database_url, redis_url, and secret_key

Documentation:
- Update README to document mandatory DATABASE_URL, REDIS_URL, and SECRET_KEY environment variables